### PR TITLE
[CON-4544] CRASH_FIX

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -68,6 +68,7 @@ NSString * AFPercentEscapedStringFromString(NSString *string) {
 
         NSString *substring = [string substringWithRange:range];
         NSString *encoded = [substring stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacterSet];
+        if (!encoded) encoded = @"";
         [escaped appendString:encoded];
 
         index += range.length;


### PR DESCRIPTION
added saftey check in case of encoded string is nil replace it with empty string 
If encoding fails the string returns nil and when we try to append it gives crash to prevent it added a safety check that will prevent it from crashing